### PR TITLE
Better deduction of centuries for centennials.

### DIFF
--- a/Sources/SwedishPNR/SwedishPNR.swift
+++ b/Sources/SwedishPNR/SwedishPNR.swift
@@ -88,12 +88,12 @@ public struct Parser {
     }
 
     private func deduceCenturyFromBirthDate(_ birthDate: DateComponents, _ reference: Date, _ isCentennial: Bool) throws -> DateComponents {
-        var presentTime = reference
-        var century = swedishCalendar.component(.year, from: presentTime) / 100
+        let presentTime = reference
+        let presentDate = swedishCalendar.dateComponents([.year, .month, .day], from: presentTime)
+        var century = presentDate.year! / 100
 
         if isCentennial {
             century -= 1
-            presentTime = swedishCalendar.date(byAdding: .year, value: -100, to: presentTime)!
         }
 
         var candidate = DateComponents(
@@ -102,7 +102,9 @@ public struct Parser {
             day: birthDate.day! > 60 ? birthDate.day! - 60 : birthDate.day
         )
 
-        if (!candidate.isValidDate(in: swedishCalendar) || swedishCalendar.compare(swedishCalendar.date(from: candidate)!, to: presentTime, toGranularity: isCentennial ? .year : .day) == .orderedDescending) {
+        if (!candidate.isValidDate(in: swedishCalendar)
+            || swedishCalendar.compare(swedishCalendar.date(from: candidate)!, to: presentTime, toGranularity: .day) == .orderedDescending
+            || (isCentennial && swedishCalendar.dateComponents([.year], from: candidate, to: presentDate).year! < 100)) {
             century -= 1
             candidate.year = 100*century + birthDate.year!
             

--- a/Tests/SwedishPNRTests/SwedishPNRTests.swift
+++ b/Tests/SwedishPNRTests/SwedishPNRTests.swift
@@ -57,7 +57,7 @@ final class SwedishPNRTests: XCTestCase {
 
             test(name: "deduce cent 100+",   input:   "171210+0005", normalized: "19171210-0005", birthDateComponents: self.components(1917, 12, 10)),
             test(name: "deduce cent 100+",   input:   "160601+0005", normalized: "19160601-0005", birthDateComponents: self.components(1916,  6,  1)),
-            test(name: "deduce cent 100+",   input:   "171218+0007", normalized: "19171218-0007", birthDateComponents: self.components(1917, 12, 18)),
+            test(name: "deduce cent 100+",   input:   "171218+0007", normalized: "18171218-0007", birthDateComponents: self.components(1817, 12, 18)),
             test(name: "deduce cent 100+",   input:   "180601+0003", normalized: "18180601-0003", birthDateComponents: self.components(1818,  6,  1)),
         ]
         


### PR DESCRIPTION
Change algorithm so that centennials always end up over 100 years old relative the reference date.